### PR TITLE
Fixing npm warnings 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "test": "nodeunit test.js"
   },
-  "repository": "",
+  "repository": { 
+    "type": "git",
+    "url": "https://github.com/andris9/addressparser.git"
+  },
   "author": "Andris Reinman",
   "license": "MIT",
   "devDependencies":{


### PR DESCRIPTION
```
WARN package.json addressparser@0.1.3 No repository field.
```
