### PR TITLE
Fix issues with quoted email addresses

### DIFF
--- a/lib/addressparser.js
+++ b/lib/addressparser.js
@@ -159,6 +159,11 @@ function _handleAddress(tokens) {
         data.text = data.text.join(' ');
         data.address = data.address.join(' ');
 
+        // Prevents single or double quoted emails which fails certain email validation
+        if(data.address.match(/^(\"|\'){1}.+@.+(\"|\'){1}$/)) {
+            data.address = data.address.substring(1, data.address.length - 1);
+        }
+
         if (!data.address && isGroup) {
             return [];
         } else {

--- a/test/addressparser-test.js
+++ b/test/addressparser-test.js
@@ -216,4 +216,40 @@ describe('#addressparser', function () {
         }];
         expect(addressparser(input)).to.deep.equal(expected);
     });
+
+    it('should handle single-quoted address', function () {
+        var input = 'andris reinman <\'andris@tr.ee\'>';
+        var expected = [{
+            name: 'andris reinman',
+            address: 'andris@tr.ee'
+        }];
+        expect(addressparser(input)).to.deep.equal(expected);
+    });
+
+    it('should handle double-quoted address', function () {
+        var input = 'andris reinman <"andris@tr.ee">';
+        var expected = [{
+            name: 'andris reinman',
+            address: 'andris@tr.ee'
+        }];
+        expect(addressparser(input)).to.deep.equal(expected);
+    });
+
+    it('should handle quoted email name', function () {
+        var input = '"andris@tr.ee" <"andris@tr.ee">';
+        var expected = [{
+            name: '',
+            address: 'andris@tr.ee'
+        }];
+        expect(addressparser(input)).to.deep.equal(expected);
+    });
+
+    it('should not handle email quoted midway', function () {
+        var input = 'andris reinman <and"ris@tr.ee">';
+        var expected = [{
+            name: 'andris reinman',
+            address: 'and"ris@tr.ee"'
+        }];
+        expect(addressparser(input)).to.deep.equal(expected);
+    });
 });


### PR DESCRIPTION
This PR fixes issues with email addresses that somehow have single or double quotes in them. This becomes an issue when you run it through [validator(.js)](https://github.com/chriso/validator.js)'s isEmail validation. 
